### PR TITLE
Update GH Pages Site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # openmensa-bielefeld
 
-This project provides an openmensa parser for cafeterias by the
-Studierendenwerk Bielefeld.
+This project provides an openmensa parser for cafeterias by the Studierendenwerk Bielefeld.
+
+The feeds are hosted via GitHub pages.
+In the future the GitHub pages deployment shall also include some documentation.
+The GitHub pages deployment is accessible [here](https://thenaildev.github.io/openmensa-bielefeld/).

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,6 +8,10 @@
         
         <a href="https://github.com/TheNailDev/openmensa-bielefeld">GitHub Repository</a>
          
-        <p>The goal of this project is to provide a funtional openmensa parser for the cafeterias operated by the Studierendenwerk Bielefeld.</p>
+        <p>The goal of this project is to provide a functional OpenMensa parser for the cafeterias operated by the Studierendenwerk Bielefeld.</p>
+        
+        <p>All available mensa feeds are listed in <a href="https://thenaildev.github.io/openmensa-bielefeld/feeds/index.json">the index feed</a>.</p>
+        
+        <p>You can also access the information of the mensa feeds at the <a href="https://openmensa.org">OpenMensa Website</a> or via the OpenMensa mobile apps.</p>
     </body>
 </html>


### PR DESCRIPTION
This adds some minor information to the index page of the GH pages deployment.
The page now links to the index.json feed.
Additionally the readme now also links to the GH pages deployment.