### PR TITLE
Enable data parsing for following week

### DIFF
--- a/swbi_parser.py
+++ b/swbi_parser.py
@@ -8,6 +8,30 @@ def _remove_multiple_whitespaces(s: str):
     return ' '.join(s.split()).strip()
 
 def parse_mensa_plan(url: str):
+    canteen = LazyBuilder()
+    
+    # updates canteen with data of current week
+    # the data of the current week is necessary
+    # thus, if an error occurs, parsing for this mensa is cancelled (by propagating the error)
+    canteen = update_canteen(canteen, url)
+    
+    # try to get canteen data for next week
+    # data for the next week is available by appending 'nächste-woche' to the url
+    # The 'ä' in this appendix needs to be escaped as '%c3%a4'
+    # if an error occurs during parsing, the program will continue without next weeks data
+    if url[-1] != '/':
+        url += '/'
+    next_week_url = url
+    next_week_url += 'n%c3%a4chste-woche/'
+    try:
+        canteen = update_canteen(canteen, next_week_url)
+    except Exception as e:
+        print(f'Could not load next week data for {url}')
+        print(f'Exception: {e}')
+    
+    return canteen.toXMLFeed()
+
+def update_canteen(canteen, url: str):
     soup = None
     with urllib.request.urlopen(url) as f:
         soup = BeautifulSoup(f.read(), 'html.parser')
@@ -16,8 +40,6 @@ def parse_mensa_plan(url: str):
         raise Exception(f'Could not read from url {url}')
     
     menuDays = soup.find_all('div', class_='menuDay')
-    
-    canteen = LazyBuilder()
     
     for menuDay in menuDays:
         # dates are formatted as YYYYMMDD, eg 20230401 for April 1st 2023
@@ -54,7 +76,7 @@ def parse_mensa_plan(url: str):
             
             canteen.addMeal(date, category, name, prices=prices, notes=notes)
         
-    return canteen.toXMLFeed()
+    return canteen
 
 if __name__ == '__main__':
     # For debug purposes do parsing for Bielefeld Mensa X


### PR DESCRIPTION
This updates the parser, to also get data for next weeks menu.
Thus, the full feed of the mensas now contain menu data for two weeks, instead of only the current week.