### PR TITLE
Add meal details to the meal notes

### DIFF
--- a/swbi_parser.py
+++ b/swbi_parser.py
@@ -81,9 +81,7 @@ def update_canteen(canteen, url: str):
                         details_content = details_a['data-bs-content']
                         details_soup = BeautifulSoup(details_content, 'html.parser')
                         if details_soup is not None:
-                            co2_footprint_span = details_soup.find('span', class_='menuItem__co2__value')
-                            if co2_footprint_span is not None:
-                                notes += [ f'CO2: {_remove_multiple_whitespaces(co2_footprint_span.string)}' ]
+                            notes += _generate_notes_from_meal_details(details_soup)
                     canteen.addMeal(date, category, name, prices=prices, notes=notes)
             else:
                 category = menuItem.find('span', class_='menuItem__line').string.strip()
@@ -91,12 +89,32 @@ def update_canteen(canteen, url: str):
                 if menuItemText is not None:
                     # Some menu items might have an empty text
                     notes += [ _remove_multiple_whitespaces(menuItemText) ]
-                co2_footprint_span = menuItem.find('span', class_='menuItem__co2__value')
-                if co2_footprint_span is not None:
-                    notes += [ f'CO2: {_remove_multiple_whitespaces(co2_footprint_span.string)}' ]
+                notes += _generate_notes_from_meal_details(menuItem)
                 canteen.addMeal(date, category, name, prices=prices, notes=notes)
         
     return canteen
+
+def _generate_notes_from_meal_details(details_soup):
+    notes = []
+    co2_footprint_span = details_soup.find('span', class_='menuItem__co2__value')
+    if co2_footprint_span is not None:
+        notes += [ f'CO2: {_remove_multiple_whitespaces(co2_footprint_span.string)}' ]
+    additives_div = details_soup.find('div', class_='menuItem__additives')
+    if additives_div is not None:
+        for custombadge_span in additives_div.find_all('span', class_='custombadge'):
+            notes += [ _generate_note_from_custombadge(custombadge_span) ]
+    allergens_div = details_soup.find('div', class_='menuItem__allergens')
+    if allergens_div is not None:
+        for custombadge_span in allergens_div.find_all('span', class_='custombadge'):
+            notes += [ _generate_note_from_custombadge(custombadge_span) ]
+    return notes
+
+def _generate_note_from_custombadge(custombadge):
+    # each custombadge consists of two child elements.
+    # the first child is the badge code, the second child is the actual description of the badge
+    code = _remove_multiple_whitespaces(custombadge.contents[0].string)
+    description = _remove_multiple_whitespaces(custombadge.contents[1])
+    return f'{code}) {description}'
 
 if __name__ == '__main__':
     # For debug purposes do parsing for Bielefeld Mensa X


### PR DESCRIPTION
This PR adds information regarding additives, allergens and the CO2 footprint to meal notes.

#### Comparison between old and new version:

Previous output:
```xml
<meal>
  <name>Leberkäse mit Spiegelei</name>
  <price role="employee">3.50</price>
  <price role="other">3.50</price>
  <price role="student">3.00</price>
</meal>
```

New output:
```xml
<meal>
  <name>Leberkäse mit Spiegelei</name>
  <note>A22) Ei</note>
  <note>A30) Senf</note>
  <note>CO2: 677g</note>
  <note>Z1) mit Farbstoff</note>
  <note>Z2) mit Konservierungsstoff</note>
  <note>Z3) mit Antioxidationsmittel</note>
  <note>Z8) mit Phosphat</note>
  <note>Z9) mit einer Zuckerart oder Süßungsmittel</note>
  <price role="employee">3.50</price>
  <price role="other">3.50</price>
  <price role="student">3.00</price>
</meal>
```