### PR TITLE
Update Actions to most recent versions

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -28,9 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
       - name: Set up Python 3.11
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: "3.11"
       - name: Install python dependencies
@@ -40,9 +40,9 @@ jobs:
       - name: Move feeds into docs directory
         run: mv feeds docs
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4.0.0
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3.0.1
         with:
           # Upload the contents of the docs directory, which also includes the openmensa feeds
           path: 'docs/'
@@ -56,4 +56,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4.0.4


### PR DESCRIPTION
According to https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ actions using Node.js 16 are deprecated and should be updated to use Node.js 20.
The deployment workflow has also shown warnings regarding this matter already.

To fix the issue, all actions have been updated to their most recent versions:

- checkoutv4.1.1
- setup-python@v5.0.0
- configure-pages@v4.0.0
- upload-pages-artifact@v3.0.1
- deploy-pages@v4.0.4