### PR TITLE
Add retry mechanism for XML feed generation

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -36,7 +36,19 @@ jobs:
       - name: Install python dependencies
         run: python -m pip install --upgrade pip && pip install -r requirements.txt
       - name: Generate xml feeds
+        id: generate1
         run: python create_feeds.py
+        continue-on-error: true
+      - name: Wait and retry
+        if: ${{ steps.generate1.outcome == 'failure' }}
+        run: |
+          sleep 300
+          python create_feeds.py
+        id: generate2
+        continue-on-error: true
+      - name: Fail if second attempt also fails
+        if: ${{ steps.generate1.outcome == 'failure' && steps.generate2.outcome == 'failure' }}
+        run: exit 1
       - name: Load old website from cache
         uses: actions/cache@v4.2.0
         with:

--- a/create_feeds.py
+++ b/create_feeds.py
@@ -37,6 +37,9 @@ def create_feeds():
         except urllib.error.HTTPError as e:
             print(f'Fatal HTTP error encountered at {location[0]}: {e}')
             raise
+        except urllib.error.URLError as e:
+            print(f'Connection issue encountered at {location[0]}: {e}')
+            raise
         except RemoteDisconnected as e:
             print(f'Remote end closed connection without response at {location[0]}: {e}')
             raise

--- a/create_feeds.py
+++ b/create_feeds.py
@@ -6,7 +6,7 @@ import swbi_parser
 gh_pages_url = 'https://thenaildev.github.io/openmensa-bielefeld/'
 
 swbi_locations = [
-    ('bielefeld_mensa-x', 'https://www.studierendenwerk-bielefeld.de/essen-trinken/speiseplan/bielefeld/mensa-x/'),
+    ('bielefeld_mensa-x', 'https://www.studierendenwerk-bielefeld.de/essen-trinken/speiseplan/bielefeld/mensa-x/gggg'),
     ('detmold_mensa-hfm', 'https://www.studierendenwerk-bielefeld.de/essen-trinken/speiseplan/detmold/mensa-hfm/'),
     ('detmold_mensa-th-owl', 'https://www.studierendenwerk-bielefeld.de/essen-trinken/speiseplan/mensa-th-owl/'),
     ('hoexter_mensa-th-owl', 'https://www.studierendenwerk-bielefeld.de/essen-trinken/speiseplan/hoexter/mensa-th-owl/'),
@@ -33,8 +33,8 @@ def create_feeds():
             mensa_listing[location[0]] = gh_pages_url + meta_filename
             print(f'Created feed {location[0]}')
         except Exception as e:
-            if 'HTTP Error 5' in str(e):
-                print(f'Fatal 5xx error encountered at {location[0]}: {e}')
+            if 'HTTP Error' in str(e):
+                print(f'Fatal HTTP error encountered at {location[0]}: {e}')
                 raise
             print(f'Exception during generation of feed {location[0]}: {e}')
     # Generate the index.json containing all feeds

--- a/create_feeds.py
+++ b/create_feeds.py
@@ -36,6 +36,9 @@ def create_feeds():
             if 'HTTP Error' in str(e):
                 print(f'Fatal HTTP error encountered at {location[0]}: {e}')
                 raise
+            elif 'Remote end closed connection without response' in str(e):
+                print(f'Connection closed unexpectedly at {location[0]}: {e}')
+                raise
             print(f'Exception during generation of feed {location[0]}: {e}')
     # Generate the index.json containing all feeds
     with open(f'{feed_directory_name}/index.json', 'w', encoding='utf-8') as f:

--- a/create_feeds.py
+++ b/create_feeds.py
@@ -6,7 +6,7 @@ import swbi_parser
 gh_pages_url = 'https://thenaildev.github.io/openmensa-bielefeld/'
 
 swbi_locations = [
-    ('bielefeld_mensa-x', 'https://www.studierendenwerk-bielefeld.de/essen-trinken/speiseplan/bielefeld/mensa-x/gggg'),
+    ('bielefeld_mensa-x', 'https://www.studierendenwerk-bielefeld.de/essen-trinken/speiseplan/bielefeld/mensa-x/'),
     ('detmold_mensa-hfm', 'https://www.studierendenwerk-bielefeld.de/essen-trinken/speiseplan/detmold/mensa-hfm/'),
     ('detmold_mensa-th-owl', 'https://www.studierendenwerk-bielefeld.de/essen-trinken/speiseplan/mensa-th-owl/'),
     ('hoexter_mensa-th-owl', 'https://www.studierendenwerk-bielefeld.de/essen-trinken/speiseplan/hoexter/mensa-th-owl/'),

--- a/create_feeds.py
+++ b/create_feeds.py
@@ -1,5 +1,7 @@
 import os
 import json
+import urllib.error
+from http.client import RemoteDisconnected
 
 import swbi_parser
 
@@ -32,13 +34,13 @@ def create_feeds():
                 f.write(meta_feed)
             mensa_listing[location[0]] = gh_pages_url + meta_filename
             print(f'Created feed {location[0]}')
+        except urllib.error.HTTPError as e:
+            print(f'Fatal HTTP error encountered at {location[0]}: {e}')
+            raise
+        except RemoteDisconnected as e:
+            print(f'Remote end closed connection without response at {location[0]}: {e}')
+            raise
         except Exception as e:
-            if 'HTTP Error' in str(e):
-                print(f'Fatal HTTP error encountered at {location[0]}: {e}')
-                raise
-            elif 'Remote end closed connection without response' in str(e):
-                print(f'Connection closed unexpectedly at {location[0]}: {e}')
-                raise
             print(f'Exception during generation of feed {location[0]}: {e}')
     # Generate the index.json containing all feeds
     with open(f'{feed_directory_name}/index.json', 'w', encoding='utf-8') as f:

--- a/create_feeds.py
+++ b/create_feeds.py
@@ -33,6 +33,9 @@ def create_feeds():
             mensa_listing[location[0]] = gh_pages_url + meta_filename
             print(f'Created feed {location[0]}')
         except Exception as e:
+            if 'HTTP Error 5' in str(e):
+                print(f'Fatal 5xx error encountered at {location[0]}: {e}')
+                raise
             print(f'Exception during generation of feed {location[0]}: {e}')
     # Generate the index.json containing all feeds
     with open(f'{feed_directory_name}/index.json', 'w', encoding='utf-8') as f:


### PR DESCRIPTION
Hey,
Your workflow ran into an error without the workflow failing. As a result, many canteens were not accessible via your GitHub Pages Page.

```
Created feed bielefeld_mensa-x
Could not load next week data for https://www.studierendenwerk-bielefeld.de/essen-trinken/speiseplan/detmold/mensa-hfm/
Exception: Remote end closed connection without response
Created feed detmold_mensa-hfm
Exception during generation of feed detmold_mensa-th-owl: HTTP Error 503: Service Unavailable
Could not load next week data for https://www.studierendenwerk-bielefeld.de/essen-trinken/speiseplan/hoexter/mensa-th-owl/
Exception: Remote end closed connection without response
Created feed hoexter_mensa-th-owl
Exception during generation of feed lemgo_mensa-th-owl: HTTP Error 500: Internal Server Error
Exception during generation of feed minden_mensa-hsbi: Remote end closed connection without response
Created index.json
```

I have fixed this, if it fails again, it waits 5 minutes and if it fails again again, the complete workflow fails and the canteens are still accessible via your GitHub Pages.

Greetings
DieSteinhose