### PR TITLE
Ignore menuitems without actual meal info

### DIFF
--- a/swbi_parser.py
+++ b/swbi_parser.py
@@ -93,7 +93,8 @@ def update_canteen(canteen, url: str):
                     if price_3 is not None:
                         prices['other'] = _remove_multiple_whitespaces(price_3.find('span', type='button').string)
                     canteen.addMeal(date, category, name, prices=prices, notes=notes)
-            else:
+            # Only handle non sidedishes when they have a price. Otherwise they are no real menu items.
+            elif prices:
                 category = menuItem.find('span', class_='menuItem__line').string.strip()
                 menuItemText = menuItem.find('p', class_='menuItem__text').string
                 if menuItemText is not None:


### PR DESCRIPTION
The generation of the höxter feed failed because for fridays the only menu item on the website is no actual meal, but just an informational message, as seen in the picture below:
![grafik](https://github.com/user-attachments/assets/6ff8f208-df7d-4345-9cef-adbd7088962d)

Now (non-sidedish) menu items that don't have a price specified (like the information message) are ignored by the parser, which avoids the errors that previously occured with the höxter feed.