### PR TITLE
Correctly handle missing graphics for menuItem_marking

### DIFF
--- a/swbi_parser.py
+++ b/swbi_parser.py
@@ -132,7 +132,7 @@ def _generate_note_from_custombadge(custombadge):
 def _generate_notes_from_menuItem_markings(item_soup):
     notes = []
     for icon in item_soup.find_all('button', class_='menuItem__marking__icon'):
-        text = icon.find('title').string
+        text = icon['data-bs-title']
         text = _remove_multiple_whitespaces(text)
         notes += [text]
     return notes


### PR DESCRIPTION
There are rare cases where menuItem_markings do not contain an actual icon. See the attached picture for an example:
<img width="612" height="142" alt="grafik" src="https://github.com/user-attachments/assets/a39cd439-cf44-495a-a094-714e66e715b9" />

Previously the parser crashed when handling such iconless menuItem_markings. By using an attribute of the menuItem_marking button itself to get the meaning of the marking instead of relying on a child element to exist, this issue seems to be fixed.